### PR TITLE
update readme to be `npmignore -i "test/fixtures"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ test/fixtures
 In the command line run:
 
 ```bash
-npmignore "test/fixtures"
+npmignore -i "test/fixtures"
 ```
 
 An `.npmignore` file will be created, or updated:


### PR DESCRIPTION
looks like a typo in the readme… I needed to do:
- `npmignore -i "test/fixtures"`

because when I just ran 
- `npmignore "test/fixtures"`

… the parameter was ignored.
